### PR TITLE
Allow passing list of codes to finish

### DIFF
--- a/nagplug/__init__.py
+++ b/nagplug/__init__.py
@@ -223,8 +223,9 @@ class Plugin(object):
         """
         if code is None:
             code = self.get_code()
+        codes = [code] if type(code) != list else code
         if message is None:
-            message = self.get_message(msglevels=[code])
+            message = self.get_message(msglevels=codes)
         if perfdata is None:
             perfdata = self.get_perfdata()
         if extdata is None:


### PR DESCRIPTION
- `finish` can take a list of codes instead of only one.

