### PR TITLE
Add LogHandler that sends logs as extdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,12 @@ This will be logged in the output
 This will also be logged
 
 ```
+
+The `extdata_log_handler` method returns a convenient `LogHandler` for
+Python's `logging` framework that registers all output logs as extdata.
+
+```python
+log = logging.getLogger()
+log.addHandler(plugin.extdata_log_handler())
+log.info('This log will be registered as extdata')
+```

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The `extdata_log_handler` method returns a convenient `LogHandler` for
 Python's `logging` framework that registers all output logs as extdata.
 
 ```python
+>>> import logging
 >>> log = logging.getLogger()
 >>> log.addHandler(plugin.extdata_log_handler())
 >>> log.info('This log will be registered as extdata')

--- a/README.md
+++ b/README.md
@@ -168,7 +168,11 @@ The `extdata_log_handler` method returns a convenient `LogHandler` for
 Python's `logging` framework that registers all output logs as extdata.
 
 ```python
-log = logging.getLogger()
-log.addHandler(plugin.extdata_log_handler())
-log.info('This log will be registered as extdata')
+>>> log = logging.getLogger()
+>>> log.addHandler(plugin.extdata_log_handler())
+>>> log.info('This log will be registered as extdata')
+>>> log.debug('This one also')
+>>> print(plugin.get_extdata())
+This log will be registered as extdata
+This one also
 ```

--- a/nagplug/__init__.py
+++ b/nagplug/__init__.py
@@ -30,6 +30,7 @@ import signal
 import re
 import argparse
 import traceback
+import logging
 
 
 OK = 0
@@ -46,6 +47,16 @@ class ArgumentParserError(Exception):
 class ThrowingArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         raise ArgumentParserError(message)
+
+
+class NagplugLoggingHandler(logging.StreamHandler):
+    def __init__(self, plugin):
+        self.plugin = plugin
+        super(NagplugLoggingHandler, self).__init__()
+
+    def emit(self, record):
+        message = self.format(record)
+        self.plugin.add_extdata(message)
 
 
 class Plugin(object):
@@ -375,6 +386,15 @@ class Plugin(object):
             the extended data string
         """
         return '\n'.join(self._extdata)
+    
+    # Utils
+
+    def extdata_log_handler(self):
+        """
+        returns:
+            NagplugLogHandler linked to this instance
+        """
+        return NagplugLogHandler(self)
 
 
 class Result(object):


### PR DESCRIPTION
Convenience tool for forwarding logs as extdata

Usage:
```python
import nagplug
import logging

log = logging.getLogger()
plugin = nagplug.Plugin()
log.addHandler(plugin.extdata_log_handler())

log.info('This log will be part of extdata')
plugin.get_extdata() # 'This log will be part of extdata'
```